### PR TITLE
Add dependabot for bundler and npm, and fix duplicate URL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,23 @@ updates:
     labels:
       - "github_actions"
       - "dependencies"
+
+  - package-ecosystem: "npm"
+    # Look for `package.json` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    labels:
+      - "node.js"
+      - "dependencies"
+
+  - package-ecosystem: 'bundler'
+    # Look for `Gemfile` in the `root` directory
+    directory: '/'
+    # Check for updates once a week
+    schedule:
+      interval: 'weekly'
+    labels:
+      - "bundler"
+      - "dependencies"

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,7 +4,7 @@ antora:
   - '@antora/pdf-extension'
 site:
   title: Fawkes
-  start_page: fawkes::index.adoc
+  start_page: docs::index.adoc
   robots: allow
 content:
   sources:


### PR DESCRIPTION
Adds dependabot configuration for `bundler` (`Gemfile`) and `npm` (`package.json`).

Also fixes the duplicate URL for fawkes-docs (https://github.com/Cray-HPE/fawkes-docs/pull/12)

Before:
```
https://cray-hpe.github.io/fawkes/fawkes/latest/services
                           ^      ^
                           | repo |
                                  | component name
```

After:

```
https://cray-hpe.github.io/fawkes/docs/latest/services
```

Observe in the photo below that "Fawkes" still shows as the component's name in the bottom left, but the URL now shows `fawkes/docs`.

![image](https://github.com/Cray-HPE/fawkes/assets/7772179/70712801-11f9-4491-82f1-2db735899fe6)
