### PR TITLE
Fix empty `vendor/` directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
 
     - name: Install Ruby dependencies
       run: |
+        env
+        export PATH=$HOME/bin:$PATH
+        env
         make .bundle
 
     - name: Install Node.js

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -109,7 +109,7 @@ pipeline {
                 docker {
                     label "${PRIMARY_NODE}"
                     reuseNode true
-                    args "-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+                    args "--env DIND_USER_HOME=$HOME -u root -v $HOME:$HOME -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
                     image "${sleImage}"
                 }
             }

--- a/release/binaries/index.yml
+++ b/release/binaries/index.yml
@@ -43,3 +43,10 @@ github.com/vmware-tanzu:
           - velero-v1.6.3-linux-amd64.tar.gz
         v1.7.2:
           - velero-v1.7.2-linux-amd64.tar.gz
+
+github.com/gruntwork-io:
+  projects:
+    terragrunt:
+      releases:
+        v0.52.4:
+          - terragrunt_linux_amd64

--- a/release/build.sh
+++ b/release/build.sh
@@ -85,7 +85,13 @@ sed -i'' 's/0\.0\.0/'"$RELEASE_VERSION"'/g' "${BUILD_DIR}/nexus-repositories.yml
 mkdir -p "${BUILD_DIR}/security" && curl -sfSLRo "${BUILD_DIR}/security/hpe-signing-key.asc" "https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc"
 
 # Save quay.io/skopeo/stable images for use in upload.sh
-vendor-install-deps "$(basename "$BUILD_DIR")" "${BUILD_DIR}/vendor"
+if [ -n "${DIND_USER_HOME:-}" ]; then
+    mkdir -p "${DIND_USER_HOME}/vendor"
+    vendor-install-deps "${DIND_USER_HOME}/vendor"
+    rsync -rltDv "${DIND_USER_HOME}/vendor" "${BUILD_DIR}"
+else
+    vendor-install-deps "${BUILD_DIR}/vendor"
+fi
 
 # Generate the tar.
 rm -rf "${RELEASE_DIR}/dist" && mkdir "${RELEASE_DIR}/dist"

--- a/release/lib/build.sh
+++ b/release/lib/build.sh
@@ -194,7 +194,6 @@ export -f download-internal-with-sha
 function vendor-install-deps() {
     local include_skopeo=1
     local creds=''
-    local release
     local destdir
 
     while [[ $# -gt 2 ]]; do

--- a/release/lib/build.sh
+++ b/release/lib/build.sh
@@ -34,6 +34,8 @@ if [[ "$yq_version" =~ '/^v3/' ]]; then
     exit 1
 fi
 
+export SKOPEO_IMAGE='artifactory.algol60.net/csm-docker/stable/quay.io/skopeo/stable:v1'
+
 if [ -z "${ARTIFACTORY_USER:-}" ] || [ -z "${ARTIFACTORY_TOKEN:-}" ]; then
     echo >&2 "Missing authentication information for image download. Please set ARTIFACTORY_USER and ARTIFACTORY_TOKEN environment variables."
     exit 1

--- a/release/lib/build.sh
+++ b/release/lib/build.sh
@@ -217,11 +217,9 @@ function vendor-install-deps() {
 
     creds="${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}"
 
-    release="$1"
-    destdir="$2"
+    destdir="$1"
 
     [[ -d "$destdir" ]] || mkdir -p "$destdir"
-
 
     if [[ "${include_skopeo:-1}" -eq 1 ]]; then
         docker run --rm -u "$(id -u):$(id -g)" "${podman_run_flags[@]}" \
@@ -230,7 +228,10 @@ function vendor-install-deps() {
             "$SKOPEO_IMAGE" \
             copy \
             ${creds:+--src-creds "${creds}"} \
-            "docker://${SKOPEO_IMAGE}" "docker-archive:/data/skopeo.tar:skopeo:${release}"
+            "docker://${SKOPEO_IMAGE}" "docker-archive:/data/skopeo.tar:$(basename "$SKOPEO_IMAGE")"
+        if [ ! -f "${destdir}/skopeo.tar" ]; then
+            return 1
+        fi
     fi
 
 }

--- a/release/lib/install.sh
+++ b/release/lib/install.sh
@@ -184,9 +184,6 @@ declare -a vendor_images=()
 # Loads vendored images into podman's image storage to facilitate installation.
 # Product install scripts should call this function before using any functions
 # which use CRAY_NEXUS_SETUP_IMAGE or SKOPEO_IMAGE to interact with Nexus.
-#
-# Product install scripts should call `clean-install-deps` when finished to
-# remove images loaded into podman.
 function load-install-deps() {
 
     if [[ -f "${LIB_DIR}/../vendor/skopeo.tar" ]]; then

--- a/release/lib/util.sh
+++ b/release/lib/util.sh
@@ -24,7 +24,6 @@
 #
 set -euo pipefail
 
-export SKOPEO_IMAGE='artifactory.algol60.net/csm-docker/stable/quay.io/skopeo/stable:v1'
 
 declare -a podman_run_flags=(--network host)
 export podman_run_flags

--- a/release/rpm/noos/index.yml
+++ b/release/rpm/noos/index.yml
@@ -23,4 +23,4 @@
 #
 artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/noos:
   rpms:
-    - gru/gru-0.0.3-1.x86_64
+    - gru/gru-0.0.4-1.x86_64

--- a/release/rpm/sle-15sp4/index.yml
+++ b/release/rpm/sle-15sp4/index.yml
@@ -23,4 +23,4 @@
 #
 artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-15sp4:
   rpms:
-    - crucible/crucible-0.0.12-1.x86_64
+    - crucible/crucible-0.0.14-1.x86_64

--- a/release/rpm/sle-15sp5/index.yml
+++ b/release/rpm/sle-15sp5/index.yml
@@ -23,4 +23,4 @@
 #
 artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-15sp5:
   rpms:
-    - crucible/crucible-0.0.12-1.x86_64
+    - crucible/crucible-0.0.14-1.x86_64


### PR DESCRIPTION
The `vendor/` directory is empty in our tarballs built from Jenkins.

Since we use Docker-in-Docker, the way we mount volumes needs to change. When we mount a volume in the second container, it's not actually mounting from the first container. Since we mount `docker.sock` from the host into the container, we're actually communicating with the host's docker instance. This means our mount is actually coming from the host.

To work around that, we just need to pass the same mount into both containers.

This also addresses a few other issues:
- Adds terragrunt
- Fixes `load-vendor-image`
- Fixes doc publishing