### PR TITLE
Bootstrap `NEXUS_REGISTRY`

### DIFF
--- a/release/lib/install.sh
+++ b/release/lib/install.sh
@@ -27,7 +27,14 @@ set -euo pipefail
 : "${NEXUS_URL:="http://packages/nexus"}"
 : "${NEXUS_REGISTRY:="registry:5000"}"
 
+# If NEXUS_URL is localhost, then assume our registry is as well. Localhost should only
+# be used in a bootstrapping context.
+if [[ "$NEXUS_URL" =~ "localhost" ]]; then
+    NEXUS_REGISTRY=localhost:${NEXUS_REGISTRY##*:}
+fi
+
 export NEXUS_URL
+export NEXUS_REGISTRY
 
 LIB_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${LIB_DIR}/util.sh"


### PR DESCRIPTION
Our docs set `localhost` for the `NEXUS_URL`, because during the time the `upload.sh` script is invoked DNS is not ready.

With DNS not being ready, `registry` won't work either. The `upload.sh` script fails when it gets to Docker images.

Instead of having our users set two env. vars, just infer that if `NEXUS_URL` is localhost that we should set `NEXUS_REGISTRY` to localhost.
