### PR TITLE
Manifest Updates

### DIFF
--- a/release/rpm/sle-15sp4/index.yml
+++ b/release/rpm/sle-15sp4/index.yml
@@ -23,4 +23,4 @@
 #
 artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-15sp4:
   rpms:
-    - crucible/crucible-0.0.15-1.x86_64
+    - crucible/crucible-0.0.16-1.x86_64

--- a/release/rpm/sle-15sp5/index.yml
+++ b/release/rpm/sle-15sp5/index.yml
@@ -23,4 +23,4 @@
 #
 artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-15sp5:
   rpms:
-    - crucible/crucible-0.0.15-1.x86_64
+    - crucible/crucible-0.0.16-1.x86_64


### PR DESCRIPTION
Contains crucible fixes from https://github.com/Cray-HPE/crucible/pull/33
Also includes new node-images: https://github.com/Cray-HPE/node-images/releases/tag/6.1.53 (or newer)
